### PR TITLE
Fix/broken generator script

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -41,8 +41,8 @@
           },
           {
             "name": "year",
-            "type": "date",
-            "description": "Annual data (YYYY)"
+            "type": "string",
+            "description": "Annual data mainly in YYYY format, but also may include stings Eg: Total 1st trading period (05-07)"
           },
           {
             "name": "value",

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -2,10 +2,8 @@
 #import os
 import urllib
 import zipfile
-#import dataconverters.xls
-#from operator import itemgetter
-# first run the extract
-# os.system('. scripts/constituents.sh')
+import csv
+
 version = '19'
 source = "http://www.eea.europa.eu/data-and-maps/data/\
 european-union-emissions-trading-scheme-eu-ets-data-from-citl-7/\
@@ -22,41 +20,8 @@ def execute():
         z.extractall('tmp/')
 
     with open(csvfile, 'r') as infile, open(out_path,'w') as outfile:
-        for line in infile:
-            line = line.replace('\t',',')
-            outfile.write(line)
+        csvreader = csv.reader(infile, delimiter='\t')
+        csvwriter = csv.writer(outfile)
+        csvwriter.writerows(csvreader)
 
-    '''
-    records = []
-    with open(in_path) as f:
-        for line in f:
-            if len(line.split("\t"))==4 :
-                records.append(line.split("\t"))
-        #reader = csv.reader(f)
-        #records = list(reader)
-
-    #header = records[0]
-    #header[0], header[1] = header[1], header[0]
-    header = ['Age of Ice', 'CO2 Concentration', 'Age of Air', 'Depth']
-    #records = records[21:]
-    #print records[0]
-    #return
-    for i in records:
-        i[3] = i[3].strip()
-        i[0],i[1] = i[1],i[0] #exchange age of ice with depth
-        i[1],i[3] = i[3],i[1] #exchange depth with ppm
-    #print records[0]
-    #sort in descending order of years BP
-    records.reverse()
-    #records = sorted(records, key=float(itemgetter(0)))
-    #header = ['Date', 'Price (Dollars per million btu)']
-    # data begins on row 4
-    #records = records[3:]
-
-    #header = [ [ fixsymbol(x[1]) ] for x in header ]
-
-    writer = csv.writer(open(out_path, 'w'), lineterminator='\n')
-    writer.writerow(header)
-    writer.writerows(records)
-'''
 execute()


### PR DESCRIPTION
The script was not considering the fact that there might be quoted columns Eg: 
`AT	Austria	30 Production of lime, or calcination of dolomite/magnesite 1.1 Freely allocated allowances 2005	1320288	tonne of CO2 equ.`
Note the comma in 4th column. When writing this into output csv file (with comas) it was resulting with extra columns in CSV. 

PR includes 
* changes in script - using csv lib to read file instead of just opening file and writing with csv lib instead of just replacing `\t` with comas (`,`) and writing line by line. 
* Data updated according to changes above
* metadata update - inside datapackage.json year field had type of `date`, this was true for most of the row, but there are rows in data that have year column that is type of string. Eg: `Total 3rd trading period (13-20)`. This is clearly not date type. So type is changed to string 